### PR TITLE
feat(get-file): add query support for file retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,14 +170,37 @@ The `--fields` option accepts any combination of these Google Drive API fields:
 
 ### View File Details
 
-Get detailed information about a specific file:
+Get detailed information about a specific file. You can use either a file ID or a search query:
+
 ```bash
+# Get file details by ID
 zenodotos get-file <file_id>
+
+# Get file details by search query
+zenodotos get-file --query "name contains 'My Document'"
 ```
 
 Example:
 ```bash
 zenodotos get-file 1abc...xyz
+```
+
+#### Query-Based File Retrieval
+
+Get file details by searching for them instead of using file IDs:
+
+```bash
+# Get file by exact name
+zenodotos get-file --query "name = 'My Important Document'"
+
+# Get file containing specific text
+zenodotos get-file --query "name contains 'report'"
+
+# Get file by MIME type
+zenodotos get-file --query "mimeType = 'application/vnd.google-apps.document'"
+
+# Get file modified recently
+zenodotos get-file --query "modifiedTime > '2024-01-01'"
 ```
 
 #### Customize Output Fields

--- a/docs/source/get-file-command.md
+++ b/docs/source/get-file-command.md
@@ -5,17 +5,20 @@ The `get-file` command retrieves and displays detailed information about a speci
 ## Overview
 
 ```bash
-zenodotos get-file <file_id> [OPTIONS]
+zenodotos get-file [<file_id>] [OPTIONS]
 ```
 
-The get-file command retrieves comprehensive metadata for a single file identified by its ID. You can customize which information is displayed using the `--fields` option.
+The get-file command retrieves comprehensive metadata for a single file identified by its ID or search query. You can customize which information is displayed using the `--fields` option.
+
+Either `file_id` or `--query` must be provided. Use `--query` to search for files by name or other criteria.
 
 ## Arguments
 
-- `file_id` (required): The Google Drive file ID of the file to retrieve information about.
+- `file_id` (optional): The Google Drive file ID of the file to retrieve information about. Required if `--query` is not provided.
 
 ## Options
 
+- `--query TEXT`: Search query to find files to get details for (e.g., "name contains 'report'")
 - `--fields TEXT`: Comma-separated list of fields to retrieve for the file
 - `--help`: Show help message and exit
 
@@ -48,6 +51,24 @@ Get detailed information about a file with default fields:
 zenodotos get-file 1abc123def456ghi789jkl012mno345pqr678stu901vwx
 ```
 
+### Query-Based File Retrieval
+
+Get file details by searching for them instead of using file IDs:
+
+```bash
+# Get file by exact name
+zenodotos get-file --query "name = 'My Important Document'"
+
+# Get file containing specific text in the name
+zenodotos get-file --query "name contains 'report'"
+
+# Get file by MIME type
+zenodotos get-file --query "mimeType = 'application/vnd.google-apps.document'"
+
+# Get file modified recently
+zenodotos get-file --query "modifiedTime > '2024-01-01'"
+```
+
 ### Custom Fields
 
 Get only basic information:
@@ -71,7 +92,9 @@ The command handles various error conditions gracefully:
 
 - **File not found**: Displays "File not found" error when the file ID doesn't exist
 - **Permission denied**: Shows "Permission denied" when you don't have access to the file
-- **Missing file ID**: Displays help when no file ID is provided
+- **Missing file ID and query**: Displays error when neither file ID nor query is provided
+- **Multiple files found**: Shows list of matching files when query matches multiple files
+- **No files found**: Shows error when query matches no files
 - **General errors**: Shows appropriate error messages for other issues
 
 ## Use Cases
@@ -80,8 +103,11 @@ The command handles various error conditions gracefully:
 
 Before exporting a file, you might want to check its details:
 ```bash
-# Get file information
+# Get file information by ID
 zenodotos get-file 1abc123def456ghi789jkl012mno345pqr678stu901vwx
+
+# Get file information by search
+zenodotos get-file --query "name contains 'Project Report'"
 
 # Then export with appropriate format
 zenodotos export 1abc123def456ghi789jkl012mno345pqr678stu901vwx --format pdf

--- a/docs/source/library.md
+++ b/docs/source/library.md
@@ -168,6 +168,33 @@ output_file = zenodotos.search_and_export(
 )
 ```
 
+##### `search_and_get_file(query)`
+
+Search for files and get detailed information about a single match.
+
+**Parameters:**
+- `query` (str): Google Drive API query
+
+**Returns:**
+- `DriveFile`: File information object
+
+**Raises:**
+- `FileNotFoundError`: When query matches no files
+- `ValueError`: When query matches multiple files
+- `PermissionError`: When user doesn't have permission
+- `RuntimeError`: For other API errors
+
+**Example:**
+```python
+# Get file details by search
+file_info = zenodotos.search_and_get_file("name = 'My Document'")
+print(f"File: {file_info.name}, Size: {file_info.size}")
+
+# Get file by MIME type
+file_info = zenodotos.search_and_get_file("mimeType = 'application/pdf'")
+print(f"PDF file: {file_info.name}")
+```
+
 ##### `get_field_parser()`
 
 Get the FieldParser utility for field handling.

--- a/src/zenodotos/client.py
+++ b/src/zenodotos/client.py
@@ -166,6 +166,31 @@ class Zenodotos:
 
         return self.export_file(files[0].id, output_path, format)
 
+    def search_and_get_file(self, query: str) -> DriveFile:
+        """Search for files and get single match (for CLI get-file --query).
+
+        Args:
+            query: Search query to find files
+
+        Returns:
+            DriveFile object with file metadata
+
+        Raises:
+            FileNotFoundError: If no files found matching the query
+            ValueError: If multiple files found matching the query
+            PermissionError: If user doesn't have permission
+            RuntimeError: For other API errors
+        """
+        files = self.list_files(query=query, page_size=100)
+
+        if not files:
+            raise FileNotFoundError("No files found matching the query")
+
+        if len(files) > 1:
+            raise ValueError(f"Multiple files found ({len(files)} matches)")
+
+        return self.get_file(files[0].id)
+
     def get_field_parser(self) -> "FieldParser":
         """Get field parsing utilities (for CLI --fields option).
 


### PR DESCRIPTION
- Add --query option to get-file command for searching files by criteria
- Make file_id argument optional when using --query option
- Add search_and_get_file method to Zenodotos library class
- Implement proper validation for mutually exclusive file_id and query options
- Add comprehensive error handling for multiple matches and no matches
- Update command help text and documentation to reflect new functionality
- Add 8 new tests for query functionality (5 CLI + 3 library)
- Update existing test to handle new optional file_id behavior
- Improve test coverage from ~37% to 95.76% across affected modules
- Update documentation in README, get-file-command.md, and library.md
- Add query examples and usage patterns in documentation
- Maintain backward compatibility with existing file_id usage

This enhancement allows users to get file details by searching for them instead of requiring the file ID, significantly improving usability for interactive workflows where users know file names but not IDs.