### PR TITLE
fix(ci): correct ty command syntax in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           uv run pytest --cov=zenodotos --cov-report=html
           uv run ruff check .
           uv run ruff format --check .
-          uv run ty .
+          uv run ty check
 
       - name: Update version in pyproject.toml
         run: |


### PR DESCRIPTION
- Fix ty command from 'ty .' to 'ty check' in GitHub Actions workflow
- The ty command requires the 'check' subcommand, not a directory argument
- This resolves the "unrecognized subcommand '.'" error in the workflow