### PR TITLE
fix(ci): resolve release workflow bump step push permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ on:
 env:
   PYTHON_VERSION: '3.11'
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -24,6 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch full history for tagging
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -91,8 +96,10 @@ jobs:
             git config --local user.name "GitHub Action"
             git add pyproject.toml uv.lock
             git commit -m "feat(release): bump version to ${{ inputs.version }}"
-            git push origin ${{ github.ref }}
+            git push origin HEAD:${{ github.ref_name }}
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: TestPyPI Release
         if: ${{ !inputs.skip_testpypi }}
@@ -144,6 +151,8 @@ jobs:
           echo "🏷️ Creating Git tag v${{ inputs.version }}..."
           git tag v${{ inputs.version }}
           git push origin v${{ inputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release
         uses: actions/create-release@v1


### PR DESCRIPTION
- Add proper permissions section with contents:write and packages:write
- Use GITHUB_TOKEN for checkout step with proper token parameter
- Fix version bump commit step to use HEAD:${{ github.ref_name }} instead of ${{ github.ref }}
- Add GITHUB_TOKEN environment variable to version bump and tag push steps
- Ensure workflow can properly push commits and tags during release process

The release workflow was failing because it lacked proper permissions to push version bumps and tags. This fix ensures the workflow has the necessary permissions and uses the correct token configuration for all git operations.