### PR TITLE
feat(release): bump version to 0.2.3 for TXT export feature

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zenodotos"
-version = "0.2.2"
+version = "0.2.3"
 description = "A command-line interface tool for interacting with Google Drive"
 readme = "README.md"
 requires-python = ">=3.11,<4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1062,7 +1062,7 @@ wheels = [
 
 [[package]]
 name = "zenodotos"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
- Update version from 0.2.2 to 0.2.3
- This version includes the new TXT export format support

The version is now ready for the new automated release workflow. When a GitHub release is created for v0.2.3, the workflow will automatically build and publish the package to PyPI.