### PR TITLE
perf(scripts): increase timeout and retry attempts in test-package-in…

### DIFF
--- a/scripts/test-package-install.sh
+++ b/scripts/test-package-install.sh
@@ -204,8 +204,8 @@ print_success "Project initialized"
 
 # Install package with retry logic
 print_info "Installing $PACKAGE_NAME from $INDEX_NAME..."
-MAX_RETRIES=3
-RETRY_DELAY=30
+MAX_RETRIES=5
+RETRY_DELAY=60
 
 for attempt in $(seq 1 $MAX_RETRIES); do
     print_info "Installation attempt $attempt of $MAX_RETRIES..."


### PR DESCRIPTION
…stall.sh

- Increase timeout from 30 seconds to 60 seconds between retry attempts
- Increase maximum retry attempts from 3 to 5 attempts
- Improves reliability for package installation testing, especially during network issues or when PyPI/TestPyPI servers are under load
- Provides better resilience against transient network problems
- Total maximum wait time increased from 90 seconds to 300 seconds (5 attempts × 60 seconds each)