### PR TITLE
feat(export): add EPUB format support for Google Docs export

### DIFF
--- a/.cursor/rules/README.md
+++ b/.cursor/rules/README.md
@@ -15,7 +15,7 @@ This document outlines the specific rules and guidelines for the Zenodotos proje
 - All Python code must be linted and formatted using `ruff`
 - All Python code must be type-checked using `ty`
 - All Python tests must be written and executed using `pytest`
-- Run `ruff check` for linting, `ruff format` for formatting, `ty check` for type checking, and `pytest` for testing
+- Run `uv run ruff check src/ tests/` for linting, `uv run ruff format src/ tests/` for formatting, `uv run ty src/` for type checking, and `uv run pytest` for testing
 - Fix all linting, formatting, type errors, and test failures before committing
 - Configure ruff, ty, and pytest settings in pyproject.toml
 - Maintain high test coverage (minimum 80% coverage)
@@ -59,11 +59,11 @@ This document outlines the specific rules and guidelines for the Zenodotos proje
 
 ### Code Verification Process
 Before committing changes, ensure:
-1. Python code passes ruff linting (`ruff check .`)
-2. Python code is properly formatted (`ruff format .`)
-3. Python code passes type checking (`ty check .`)
-4. All tests pass (`pytest`)
-5. Documentation builds without warnings (`sphinx-build -b html docs/source docs/build/html`)
+1. Python code passes ruff linting (`uv run ruff check src/ tests/`)
+2. Python code is properly formatted (`uv run ruff format src/ tests/`)
+3. Python code passes type checking (`uv run ty src/`)
+4. All tests pass (`uv run pytest`)
+5. Documentation builds without warnings (`uv run sphinx-build -b html docs/source docs/build/html`)
 6. Build process succeeds (`uv build`)
 7. Package can be installed locally (`uv sync`)
 8. Pre-commit checks pass (`pre-commit run --all-files`)
@@ -76,7 +76,7 @@ Before committing changes, ensure:
 - Include a detailed body explaining the change and relevant decisions
 
 ### Test Coverage
-- Use `pytest-cov` to measure test coverage
+- Use `uv run pytest --cov=zenodotos --cov-report=term-missing --cov-fail-under=80` to measure test coverage
 - Ensure test coverage is at least 80% (enforced via `--cov-fail-under=80` in pyproject.toml)
 - Generate coverage reports with `--cov-report=term-missing`
 - Investigate and address uncovered code

--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ Override the default format with these options:
 - `rtf`: Rich Text Format (for Google Docs)
 - `txt`: Plain text format (for Google Docs)
 - `odt`: OpenDocument Text format (for Google Docs)
+- `epub`: EPUB format (for Google Docs)
 
 #### Examples
 
@@ -317,6 +318,9 @@ zenodotos export 1abc123def456ghi789jkl012mno345pqr678stu901vwx --format txt
 
 # Export a Google Doc to OpenDocument Text
 zenodotos export 1abc123def456ghi789jkl012mno345pqr678stu901vwx --format odt
+
+# Export a Google Doc to EPUB
+zenodotos export 1abc123def456ghi789jkl012mno345pqr678stu901vwx --format epub
 
 # Export a Google Sheet to Excel
 zenodotos export 1abc123def456ghi789jkl012mno345pqr678stu901vwx --format xlsx

--- a/docs/source/export-command.md
+++ b/docs/source/export-command.md
@@ -20,7 +20,7 @@ You can export files using either a file ID or a search query. File ID and query
 
 - `--query TEXT`: Search query to find files to export (e.g., "name contains 'report'")
 - `--output TEXT`: Output path for the exported file. If not provided, saves to current directory with document name
-- `--format [html|pdf|xlsx|csv|md|rtf|txt|odt]`: Export format (auto-detected if not specified)
+- `--format [html|pdf|xlsx|csv|md|rtf|txt|odt|epub]`: Export format (auto-detected if not specified)
 - `--verbose`: Show detailed progress information
 - `--help`: Show help message and exit
 
@@ -110,6 +110,7 @@ You can override the smart defaults with these format options:
 - `rtf`: Rich Text Format (for Google Docs)
 - `txt`: Plain text format (for Google Docs)
 - `odt`: OpenDocument Text format (for Google Docs)
+- `epub`: EPUB format (for Google Docs)
 
 ## Usage Examples
 
@@ -168,6 +169,9 @@ zenodotos export 1abc123def456ghi789jkl012mno345pqr678stu901vwx --format txt
 
 # Export a Google Doc to OpenDocument Text
 zenodotos export 1abc123def456ghi789jkl012mno345pqr678stu901vwx --format odt
+
+# Export a Google Doc to EPUB
+zenodotos export 1abc123def456ghi789jkl012mno345pqr678stu901vwx --format epub
 
 # Export a Google Sheet to CSV instead of XLSX
 zenodotos export 1abc123def456ghi789jkl012mno345pqr678stu901vwx --format csv

--- a/src/zenodotos/cli/commands.py
+++ b/src/zenodotos/cli/commands.py
@@ -161,7 +161,9 @@ def get_file(file_id, query, fields):
 )
 @click.option(
     "--format",
-    type=click.Choice(["html", "pdf", "xlsx", "csv", "md", "rtf", "txt", "odt"]),
+    type=click.Choice(
+        ["html", "pdf", "xlsx", "csv", "md", "rtf", "txt", "odt", "epub"]
+    ),
     help="Export format (auto-detected if not specified)",
 )
 @click.option(
@@ -179,7 +181,7 @@ def export(file_id, query, output, format, verbose):
     - Google Drawings: PNG
     - Google Forms: ZIP
 
-    Use --format to override the default format. Supported formats: html, pdf, xlsx, csv, md, rtf, txt, odt
+    Use --format to override the default format. Supported formats: html, pdf, xlsx, csv, md, rtf, txt, odt, epub
 
     Either FILE_ID or --query must be provided. Use --query to search for files by name or other criteria.
     """

--- a/src/zenodotos/drive/client.py
+++ b/src/zenodotos/drive/client.py
@@ -205,7 +205,17 @@ class DriveClient:
         Raises:
             ValueError: If the format is not supported.
         """
-        supported_formats = ["html", "pdf", "xlsx", "csv", "md", "rtf", "txt", "odt"]
+        supported_formats = [
+            "html",
+            "pdf",
+            "xlsx",
+            "csv",
+            "md",
+            "rtf",
+            "txt",
+            "odt",
+            "epub",
+        ]
         if format not in supported_formats:
             raise ValueError(f"Unsupported format: {format}")
 
@@ -258,6 +268,7 @@ class DriveClient:
             "rtf": "application/rtf",
             "txt": "text/plain",
             "odt": "application/vnd.oasis.opendocument.text",
+            "epub": "application/epub+zip",
         }
         return mime_type_mapping.get(format, "application/zip")
 
@@ -279,5 +290,6 @@ class DriveClient:
             "rtf": "rtf",
             "txt": "txt",
             "odt": "odt",
+            "epub": "epub",
         }
         return extension_mapping.get(format, "zip")

--- a/tests/unit/drive/test_client.py
+++ b/tests/unit/drive/test_client.py
@@ -254,7 +254,17 @@ class TestExportFormatHandling:
 
     def test_validate_format_supported(self, drive_client):
         """Test that supported formats are validated successfully."""
-        supported_formats = ["html", "pdf", "xlsx", "csv", "md", "rtf", "txt", "odt"]
+        supported_formats = [
+            "html",
+            "pdf",
+            "xlsx",
+            "csv",
+            "md",
+            "rtf",
+            "txt",
+            "odt",
+            "epub",
+        ]
 
         for format in supported_formats:
             # Should not raise any exception
@@ -279,6 +289,7 @@ class TestExportFormatHandling:
             ("rtf", "application/rtf"),
             ("txt", "text/plain"),
             ("odt", "application/vnd.oasis.opendocument.text"),
+            ("epub", "application/epub+zip"),
         ]
 
         for format, expected_mime_type in mime_type_tests:
@@ -295,6 +306,7 @@ class TestExportFormatHandling:
             ("rtf", "rtf"),
             ("txt", "txt"),
             ("odt", "odt"),
+            ("epub", "epub"),
         ]
 
         for format, expected_extension in extension_tests:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -494,6 +494,22 @@ class TestExport:
                 "test123", output_path=None, format="pdf"
             )
 
+    def test_with_epub_format(self):
+        """Test export with EPUB format."""
+        runner = CliRunner()
+        with patch("zenodotos.cli.commands.Zenodotos") as mock_zenodotos_class:
+            mock_zenodotos = Mock()
+            mock_zenodotos_class.return_value = mock_zenodotos
+
+            mock_zenodotos.export_file.return_value = "/path/to/exported/file.epub"
+
+            result = runner.invoke(cli, ["export", "test123", "--format", "epub"])
+
+            assert result.exit_code == 0
+            mock_zenodotos.export_file.assert_called_once_with(
+                "test123", output_path=None, format="epub"
+            )
+
     def test_with_output_path(self):
         """Test export with output path."""
         runner = CliRunner()


### PR DESCRIPTION
- Add EPUB format to supported export formats in DriveClient
- Update CLI command to include EPUB in format choices
- Add comprehensive tests for EPUB export functionality
- Update documentation in README.md and export-command.md
- EPUB format uses MIME type 'application/epub+zip' and file extension '.epub'
- Maintains consistency with existing export format implementation
- Users can now export Google Docs to EPUB format for e-book creation
