### PR TITLE
feat(release): implement dynamic versioning with uv-dynamic-versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,21 +56,6 @@ jobs:
           uv run ruff format --check .
           uv run ty check
 
-      - name: Verify version in pyproject.toml
-        run: |
-          # Get current version from pyproject.toml
-          CURRENT_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
-          echo "Current version in pyproject.toml: $CURRENT_VERSION"
-          echo "Target version from release tag: $VERSION"
-
-          if [ "$CURRENT_VERSION" = "$VERSION" ]; then
-            echo "✅ Version in pyproject.toml matches release tag"
-          else
-            echo "❌ Version mismatch: pyproject.toml has $CURRENT_VERSION but release tag is v$VERSION"
-            echo "Please ensure pyproject.toml version matches the release tag before publishing"
-            exit 1
-          fi
-
       - name: TestPyPI Release
         if: ${{ !inputs.skip_testpypi }}
         run: |
@@ -78,8 +63,6 @@ jobs:
           ./scripts/release.sh --testpypi
         env:
           TEST_PYPI_TOKEN: ${{ secrets.TEST_PYPI_TOKEN }}
-
-
 
       - name: Check TestPyPI availability
         if: ${{ !inputs.skip_testpypi }}
@@ -101,8 +84,6 @@ jobs:
           ./scripts/release.sh --pypi
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-
-
 
       - name: Check PyPI availability
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "uv-dynamic-versioning"]
 build-backend = "hatchling.build"
 
 [project]
 name = "zenodotos"
-version = "0.2.6"
+dynamic = ["version"]
 description = "A command-line interface tool for interacting with Google Drive"
 readme = "README.md"
 requires-python = ">=3.11,<4.0"
@@ -60,3 +60,9 @@ dev = [
     "sphinx-rtd-theme>=3.0.2",
     "ty>=0.0.1a9",
 ]
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.uv-dynamic-versioning]
+fallback-version = "0.0.0"

--- a/src/zenodotos/__init__.py
+++ b/src/zenodotos/__init__.py
@@ -1,6 +1,11 @@
 """Zenodotos - Google Drive Library and CLI Tool."""
 
-__version__ = "0.1.1"
+import importlib.metadata
+
+try:
+    __version__ = importlib.metadata.version(__name__)
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "0.0.0"  # Fallback for development mode
 
 # Main library exports
 from .client import Zenodotos

--- a/uv.lock
+++ b/uv.lock
@@ -1062,7 +1062,6 @@ wheels = [
 
 [[package]]
 name = "zenodotos"
-version = "0.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
- Replace static version in pyproject.toml with dynamic versioning
- Add uv-dynamic-versioning to build system requirements
- Update __init__.py to use importlib.metadata for version access
- Remove version validation from GitHub Actions workflow
- Add fallback version for development environments

This change enables automatic version management from Git tags, eliminating the need to manually update pyproject.toml before releases. Now creating a GitHub release with a tag (e.g., v0.2.7) will automatically use that version for the package build and publication.

The workflow is now simplified to:
1. Create GitHub release with tag
2. GitHub Actions automatically builds and publishes with correct version
3. No manual version updates or branch protection issues

Benefits:
- Single-step release process
- Version always matches Git tag
- No branch protection conflicts
- Follows Python packaging best practices
- Maintains proper version tracking in the module