### PR TITLE
chore(release): implement separated release and testing workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,26 +57,11 @@ jobs:
           uv run ty check
 
       - name: TestPyPI Release
-        if: ${{ !inputs.skip_testpypi }}
         run: |
           echo "🚀 Publishing to TestPyPI..."
           ./scripts/release.sh --testpypi
         env:
           TEST_PYPI_TOKEN: ${{ secrets.TEST_PYPI_TOKEN }}
-
-      - name: Check TestPyPI availability
-        if: ${{ !inputs.skip_testpypi }}
-        run: |
-          echo "🔍 Checking TestPyPI availability..."
-          ./scripts/check-package-availability.sh --testpypi --wait zenodotos $VERSION
-        env:
-          TEST_PYPI_TOKEN: ${{ secrets.TEST_PYPI_TOKEN }}
-
-      - name: Test TestPyPI installation
-        if: ${{ !inputs.skip_testpypi }}
-        run: |
-          echo "🧪 Testing TestPyPI installation..."
-          ./scripts/test-package-install.sh --testpypi zenodotos $VERSION
 
       - name: PyPI Release
         run: |
@@ -84,18 +69,6 @@ jobs:
           ./scripts/release.sh --pypi
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-
-      - name: Check PyPI availability
-        run: |
-          echo "🔍 Checking PyPI availability..."
-          ./scripts/check-package-availability.sh --pypi --wait zenodotos $VERSION
-        env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-
-      - name: Test PyPI installation
-        run: |
-          echo "🧪 Testing PyPI installation..."
-          ./scripts/test-package-install.sh --pypi zenodotos $VERSION
 
       - name: Verify Git tag exists
         run: |
@@ -121,13 +94,9 @@ jobs:
 
           ## Package Information
 
-          ### Verification
+          ### Publishing Status
           - ✅ Published to TestPyPI
-          - ✅ TestPyPI availability confirmed
-          - ✅ TestPyPI installation tested
           - ✅ Published to PyPI
-          - ✅ PyPI availability confirmed
-          - ✅ PyPI installation tested
 
           ### Installation
           \`\`\`bash
@@ -136,7 +105,16 @@ jobs:
 
           ### Package Links
           - **PyPI**: https://pypi.org/project/zenodotos/$VERSION/
-          - **TestPyPI**: https://test.pypi.org/project/zenodotos/$VERSION/"
+          - **TestPyPI**: https://test.pypi.org/project/zenodotos/$VERSION/
+
+          ### Testing
+          > **Note**: Package installation testing is now handled by a separate workflow.
+          >
+          > To test the package installation, use the **Test Package Installation** workflow:
+          > 1. Go to Actions → Test Package Installation
+          > 2. Click "Run workflow"
+          > 3. Configure the test parameters as needed
+          > 4. Run the test to verify installation works correctly"
 
           # Update the release
           curl -X PATCH \
@@ -156,3 +134,7 @@ jobs:
           echo ""
           echo "📋 Release updated:"
           echo "   https://github.com/${{ github.repository }}/releases/tag/v$VERSION"
+          echo ""
+          echo "🧪 Next Steps:"
+          echo "   To test package installation, use the 'Test Package Installation' workflow"
+          echo "   This allows for flexible testing with configurable wait times for index propagation."

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -1,0 +1,132 @@
+name: Test Package Installation
+
+on:
+  workflow_dispatch:
+    inputs:
+      package_name:
+        description: 'Package name to test'
+        required: true
+        default: 'zenodotos'
+        type: string
+      version:
+        description: 'Version to test (leave empty to use latest GitHub release)'
+        required: false
+        type: string
+      target_index:
+        description: 'Target index to test'
+        required: true
+        default: 'both'
+        type: choice
+        options:
+          - testpypi
+          - pypi
+          - both
+      wait_time:
+        description: 'Wait time for index propagation (seconds)'
+        required: false
+        default: '300'
+        type: string
+
+
+env:
+  PYTHON_VERSION: '3.11'
+
+permissions:
+  contents: read
+
+jobs:
+  test-package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v2
+        with:
+          version: latest
+
+      - name: Get latest release version
+        if: ${{ inputs.version == '' }}
+        run: |
+          echo "🔍 Fetching latest GitHub release version..."
+          LATEST_VERSION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/releases/latest" | \
+            jq -r '.tag_name // empty')
+
+          if [ -z "$LATEST_VERSION" ]; then
+            echo "❌ Error: No releases found or could not fetch latest release"
+            exit 1
+          fi
+
+          # Remove 'v' prefix if present
+          VERSION=${LATEST_VERSION#v}
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "✅ Latest release version: $VERSION (from tag: $LATEST_VERSION)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set version from input
+        if: ${{ inputs.version != '' }}
+        run: |
+          echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+          echo "✅ Using specified version: ${{ inputs.version }}"
+
+      - name: Display test configuration
+        run: |
+          echo "🧪 Package Installation Test Configuration"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "📦 Package: ${{ inputs.package_name }}"
+          echo "🏷️  Version: $VERSION"
+          echo "🎯 Target Index: ${{ inputs.target_index }}"
+          echo "⏱️  Wait Time: ${{ inputs.wait_time }} seconds"
+          echo ""
+
+      - name: Test TestPyPI installation
+        if: ${{ inputs.target_index == 'testpypi' || inputs.target_index == 'both' }}
+        run: |
+          echo "🧪 Testing TestPyPI installation..."
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+          # Check package availability first
+          echo "🔍 Checking TestPyPI availability for ${{ inputs.package_name }}==$VERSION..."
+          ./scripts/check-package-availability.sh --testpypi --wait --timeout ${{ inputs.wait_time }} ${{ inputs.package_name }} $VERSION
+
+          # Test installation
+          ./scripts/test-package-install.sh --testpypi --clean ${{ inputs.package_name }} $VERSION
+
+      - name: Test PyPI installation
+        if: ${{ inputs.target_index == 'pypi' || inputs.target_index == 'both' }}
+        run: |
+          echo "🚀 Testing PyPI installation..."
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+          # Check package availability first
+          echo "🔍 Checking PyPI availability for ${{ inputs.package_name }}==$VERSION..."
+          ./scripts/check-package-availability.sh --pypi --wait --timeout ${{ inputs.wait_time }} ${{ inputs.package_name }} $VERSION
+
+          # Test installation
+          ./scripts/test-package-install.sh --pypi --clean ${{ inputs.package_name }} $VERSION
+
+      - name: Test summary
+        run: |
+          echo ""
+          echo "🎉 Package Installation Test Summary"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "📦 Package: ${{ inputs.package_name }}"
+          echo "🏷️  Version: $VERSION"
+          echo "🎯 Target Index: ${{ inputs.target_index }}"
+          echo "✅ All tests completed successfully!"
+          echo ""
+          echo "💡 Next Steps:"
+          if [ "${{ inputs.target_index }}" = "testpypi" ] || [ "${{ inputs.target_index }}" = "both" ]; then
+            echo "  • TestPyPI: https://test.pypi.org/project/${{ inputs.package_name }}/"
+          fi
+          if [ "${{ inputs.target_index }}" = "pypi" ] || [ "${{ inputs.target_index }}" = "both" ]; then
+            echo "  • PyPI: https://pypi.org/project/${{ inputs.package_name }}/"
+          fi

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -357,12 +357,13 @@ The library now provides:
 - **Better Error Handling**: Each step can fail independently
 - **Reusable Components**: Scripts can be used outside the release process
 
-### Phase 2: Automated Publishing with GitHub Actions (Current Focus)
-- [x] **GitHub Actions Workflow** - Manual release workflow with workflow_dispatch
-- [x] **Release Orchestration** - Coordinate all three steps (publish → verify → test)
-- [x] **Version Management** - Manual version input with validation
+### Phase 2: Automated Publishing with GitHub Actions (Completed ✅)
+- [x] **GitHub Actions Workflow** - Automated release workflow triggered by release published
+- [x] **Separated Workflows** - Release and testing workflows separated for better reliability
+- [x] **Version Management** - Automatic version extraction from release tag with validation
 - [x] **Automated Testing** - Pre-publishing validation in isolated environments
-- [x] **GitHub Release Creation** - Automatic tag creation and release notes
+- [x] **GitHub Release Creation** - Automatic release updates with package information
+- [x] **Manual Test Workflow** - Flexible testing workflow with configurable parameters
 - [ ] **Package Signing** - GPG signing for enhanced security (future)
 - [ ] **Release Notes Generation** - Auto-generate from conventional commits (future)
 
@@ -381,12 +382,14 @@ The library now provides:
    - Repeat for PyPI if TestPyPI successful
    - Manual orchestration of steps
 
-3. **Automated Publishing** (Phase 2):
-   - Manual workflow dispatch with version input
-   - Automated version validation and update
-   - GitHub Actions orchestrates all three steps
+3. **Automated Publishing** (Phase 2 - Completed):
+   - Automatic trigger on release published
+   - Automated version extraction and validation
+   - GitHub Actions handles publishing only
    - Quality gates and validation
-   - Automated Git tagging and GitHub releases
+   - Automated GitHub release updates
+   - Separate manual testing workflow for flexible verification
+   - GitHub release version auto-detection for testing
 
 ## Maintenance
 

--- a/docs/setup/publishing.md
+++ b/docs/setup/publishing.md
@@ -307,14 +307,15 @@ If you encounter issues:
 
 Planned enhancements to the publishing process:
 
-1. **Automated GitHub Actions** workflow for tag-based releases
-2. **Automated version management** from git tags
-3. **Release notes generation** from conventional commits
+1. **Workflow linking** between release and test workflows
+2. **Automated testing** with scheduled execution
+3. **Notification integration** for test results
 4. **Package signing** with GPG keys
-5. **Automated testing** in isolated environments
+5. **Cross-platform testing** on different operating systems
 
 ## Related Documentation
 
+- [GitHub Actions Workflows](./github-actions.md) - Automated release and testing workflows
 - [Version Management](./version-management.md) - Managing tool versions
 - [Development Setup](./installation.md) - Setting up the development environment
 - [Contributing Guide](../contributing.md) - Contributing to the project

--- a/docs/setup/release-checklist.md
+++ b/docs/setup/release-checklist.md
@@ -40,30 +40,28 @@ This checklist ensures a smooth and reliable release process for Zenodotos packa
 - [ ] **Verify build artifacts**: Check `dist/` directory
 - [ ] **Test package locally**: `uv pip install dist/zenodotos-*.tar.gz`
 
-### ✅ TestPyPI Publishing
-- [ ] **Publish to TestPyPI**: `./scripts/release.sh --testpypi`
-- [ ] **Verify TestPyPI upload**: Check https://test.pypi.org/project/zenodotos/
-- [ ] **Check package availability**: `./scripts/check-package-availability.sh --testpypi`
-- [ ] **Test TestPyPI installation**: `./scripts/test-package-install.sh --testpypi`
-- [ ] **Verify CLI functionality**: Test all commands work
-- [ ] **Verify library functionality**: Test imports and basic usage
+### ✅ Automated Publishing (GitHub Actions)
+- [x] **Create GitHub release**: Triggers automatic publishing workflow
+- [x] **Automatic TestPyPI publishing**: Handled by release workflow
+- [x] **Automatic PyPI publishing**: Handled by release workflow
+- [x] **Release completion**: Workflow completes quickly after publishing
 
-### ✅ Production PyPI Publishing
-- [ ] **Publish to production PyPI**: `./scripts/release.sh --pypi`
-- [ ] **Verify production upload**: Check https://pypi.org/project/zenodotos/
-- [ ] **Check package availability**: `./scripts/check-package-availability.sh --pypi`
-- [ ] **Test production installation**: `pip install zenodotos`
-- [ ] **Verify production functionality**: Test CLI and library
+### ✅ Manual Testing (Optional)
+- [ ] **Run test workflow**: Go to Actions → Test Package Installation
+- [ ] **Configure test parameters**: Package, version, target index, wait time
+- [ ] **Verify TestPyPI installation**: Tests availability and installation
+- [ ] **Verify PyPI installation**: Tests availability and installation
+- [ ] **Review test results**: Check workflow output for success/failure
 
 ## Post-Release Verification
 
 ### ✅ Package Availability Verification
-- [ ] **Check TestPyPI availability**: `./scripts/check-package-availability.sh --testpypi`
-- [ ] **Check production PyPI availability**: `./scripts/check-package-availability.sh --pypi`
-- [ ] **Test TestPyPI installation**: `./scripts/test-package-install.sh --testpypi`
-- [ ] **Test production PyPI installation**: `./scripts/test-package-install.sh --pypi`
-- [ ] **Verify deployment times**: `./scripts/check-package-availability.sh --deployment-times`
-- [ ] **Monitor propagation**: Check availability periodically until fully propagated
+- [ ] **Use test workflow**: Go to Actions → Test Package Installation
+- [ ] **Test both indexes**: Configure target_index to "both"
+- [ ] **Set appropriate wait time**: 300s for TestPyPI, 600s for PyPI
+- [ ] **Review availability results**: Check workflow output
+- [ ] **Verify installation**: Confirm package installs and works correctly
+- [ ] **Monitor propagation**: Re-run test workflow if needed
 
 ### ✅ Installation Testing
 - [ ] **Clean environment test**: Install in fresh virtual environment
@@ -81,28 +79,31 @@ This checklist ensures a smooth and reliable release process for Zenodotos packa
 ### ✅ Git Repository Updates
 - [ ] **Version changes committed**: `git add pyproject.toml`
 - [ ] **Conventional commit message**: `git commit -m "feat: bump version to X.Y.Z"`
-- [ ] **Git tag created**: `git tag vX.Y.Z` (note the `v` prefix for semantic versioning)
-- [ ] **Tag pushed to remote**: `git push origin vX.Y.Z`
 - [ ] **Changes pushed to main**: `git push origin main`
+- [ ] **GitHub release created**: Go to Releases → Create new release
+- [ ] **Tag version**: Use `vX.Y.Z` format (e.g., `v0.2.10`)
+- [ ] **Publish release**: Triggers automated publishing workflow
 
 **Versioning Notes**:
 - Package version in `pyproject.toml`: `X.Y.Z` (without `v` prefix)
 - Git tag: `vX.Y.Z` (with `v` prefix for semantic versioning)
 
-## Automated Release (Future)
+## Automated Release (Current)
 
 ### ✅ GitHub Actions Setup
-- [ ] **Release workflow** created: `.github/workflows/release.yml`
-- [ ] **Secrets configured**: `TEST_PYPI_TOKEN`, `PYPI_TOKEN`
-- [ ] **Tag triggers** configured: `on: push: tags: ['v*']`
-- [ ] **Quality gates** implemented: Tests must pass before publishing
-- [ ] **Rollback capability** available: Package yanking if needed
+- [x] **Release workflow** created: `.github/workflows/release.yml`
+- [x] **Test workflow** created: `.github/workflows/test-package.yml`
+- [x] **Secrets configured**: `TEST_PYPI_TOKEN`, `PYPI_TOKEN`
+- [x] **Release triggers** configured: `on: release: types: [published]`
+- [x] **Quality gates** implemented: Tests must pass before publishing
+- [x] **Separated workflows** for publishing and testing
 
 ### ✅ Automated Testing
-- [ ] **Pre-publishing tests** run automatically
-- [ ] **Post-publishing tests** verify installation
-- [ ] **Cross-platform testing** (if applicable)
-- [ ] **Dependency compatibility** testing
+- [x] **Pre-publishing tests** run automatically in release workflow
+- [x] **Manual testing workflow** available for post-publishing verification
+- [x] **Configurable wait times** for index propagation delays
+- [x] **GitHub release version auto-detection** for testing
+- [x] **Flexible testing options** (TestPyPI, PyPI, or both)
 
 ## Troubleshooting
 
@@ -126,7 +127,7 @@ This checklist ensures a smooth and reliable release process for Zenodotos packa
 #### Installation Failures
 - **Issue**: Package installs but doesn't work
 - **Solution**: Check entry points and package structure
-- **Check**: Test with `./scripts/test-package-install.sh --testpypi`
+- **Check**: Use the test workflow to verify installation
 
 ## Release Notes Template
 
@@ -181,8 +182,9 @@ If automated release fails:
 1. **Check logs**: Review GitHub Actions logs
 2. **Identify issue**: Determine root cause
 3. **Fix locally**: Test fix manually
-4. **Re-run workflow**: Push new tag or manual trigger
+4. **Re-run workflow**: Create new GitHub release
 5. **Verify**: Confirm successful release
+6. **Test installation**: Use test workflow to verify package works
 
 ## Success Metrics
 

--- a/docs/setup/version-management.md
+++ b/docs/setup/version-management.md
@@ -182,6 +182,8 @@ git commit -m "chore: update ruff to 0.12.0"
 git push origin main
 
 # 5. Check GitHub Actions tab
+- Verify CI workflows pass with updated versions
+- Check that release workflow uses correct versions
 ```
 
 This system ensures that all environments use the same versions, reducing inconsistencies and maintenance overhead.


### PR DESCRIPTION
- Create new Test Package Installation workflow for manual testing
- Simplify release workflow to focus only on publishing
- Add configurable wait times and flexible testing options
- Handle TestPyPI/PyPI duality with independent testing
- Add GitHub release version auto-detection for testing
- Remove redundant clean_after parameter (GitHub Actions is ephemeral)
- Consolidate documentation into single comprehensive guide
- Update all documentation to reflect new workflow approach

Benefits:
- Resolves index propagation delay issues
- Provides flexible testing with configurable parameters
- Enables independent execution of publishing and testing
- Improves reliability and debugging capabilities
- Maintains clear separation of concerns
- Eliminates documentation redundancy
- Ensures all documentation is current and consistent

The release workflow now completes quickly after publishing, while the test workflow can be run manually with appropriate wait times for index propagation. This addresses the main issue where uv couldn't find recently published packages in the corresponding indexes.