### PR TITLE
fix(release): fix JSON escaping in GitHub release update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,8 +89,8 @@ jobs:
             "https://api.github.com/repos/${{ github.repository }}/releases/tags/v$VERSION" | \
             jq -r '.body // ""')
 
-          # Add package information to release notes
-          PACKAGE_INFO="
+          # Create package information using jq to properly escape the JSON
+          PACKAGE_INFO=$(cat << 'EOF'
 
           ## Package Information
 
@@ -99,9 +99,9 @@ jobs:
           - ✅ Published to PyPI
 
           ### Installation
-          \`\`\`bash
+          ```bash
           pip install zenodotos==$VERSION
-          \`\`\`
+          ```
 
           ### Package Links
           - **PyPI**: https://pypi.org/project/zenodotos/$VERSION/
@@ -114,14 +114,19 @@ jobs:
           > 1. Go to Actions → Test Package Installation
           > 2. Click "Run workflow"
           > 3. Configure the test parameters as needed
-          > 4. Run the test to verify installation works correctly"
+          > 4. Run the test to verify installation works correctly
+          EOF
+          )
+
+          # Combine release body with package info and escape for JSON
+          COMBINED_BODY=$(echo "$RELEASE_BODY$PACKAGE_INFO" | jq -Rs .)
 
           # Update the release
           curl -X PATCH \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${{ github.repository }}/releases/tags/v$VERSION" \
-            -d "{\"body\":\"$RELEASE_BODY$PACKAGE_INFO\"}"
+            -d "{\"body\":$COMBINED_BODY}"
 
       - name: Success message
         run: |


### PR DESCRIPTION
- Use jq to properly escape multi-line text for JSON payload
- Fix shell interpretation of newlines and special characters
- Ensure GitHub release notes are updated correctly after publishing

The previous approach was causing shell interpretation errors when trying to include multi-line markdown content in the JSON payload. This fix uses jq to properly escape the content for the GitHub API.