### PR TITLE
feat(export): add ODS format support for Google Sheets export

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ Override the default format with these options:
 - `pdf`: PDF export
 - `xlsx`: Excel format (for spreadsheets)
 - `csv`: CSV format (for spreadsheets)
+- `ods`: OpenDocument Spreadsheet format (for Google Sheets)
 - `md`: Markdown format (for Google Docs)
 - `rtf`: Rich Text Format (for Google Docs)
 - `txt`: Plain text format (for Google Docs)
@@ -324,6 +325,9 @@ zenodotos export 1abc123def456ghi789jkl012mno345pqr678stu901vwx --format epub
 
 # Export a Google Sheet to Excel
 zenodotos export 1abc123def456ghi789jkl012mno345pqr678stu901vwx --format xlsx
+
+# Export a Google Sheet to LibreOffice format (ODS)
+zenodotos export 1abc123def456ghi789jkl012mno345pqr678stu901vwx --format ods
 
 # Export a presentation to PDF
 zenodotos export 1abc123def456ghi789jkl012mno345pqr678stu901vwx --format pdf

--- a/docs/source/export-command.md
+++ b/docs/source/export-command.md
@@ -20,7 +20,7 @@ You can export files using either a file ID or a search query. File ID and query
 
 - `--query TEXT`: Search query to find files to export (e.g., "name contains 'report'")
 - `--output TEXT`: Output path for the exported file. If not provided, saves to current directory with document name
-- `--format [html|pdf|xlsx|csv|md|rtf|txt|odt|epub]`: Export format (auto-detected if not specified)
+- `--format [html|pdf|xlsx|csv|md|rtf|txt|odt|ods|epub]`: Export format (auto-detected if not specified)
 - `--verbose`: Show detailed progress information
 - `--help`: Show help message and exit
 
@@ -106,6 +106,7 @@ You can override the smart defaults with these format options:
 - `pdf`: PDF export
 - `xlsx`: Excel format (for spreadsheets)
 - `csv`: CSV format (for spreadsheets)
+- `ods`: OpenDocument Spreadsheet format (for Google Sheets)
 - `md`: Markdown format (for Google Docs)
 - `rtf`: Rich Text Format (for Google Docs)
 - `txt`: Plain text format (for Google Docs)
@@ -175,6 +176,9 @@ zenodotos export 1abc123def456ghi789jkl012mno345pqr678stu901vwx --format epub
 
 # Export a Google Sheet to CSV instead of XLSX
 zenodotos export 1abc123def456ghi789jkl012mno345pqr678stu901vwx --format csv
+
+# Export a Google Sheet to LibreOffice format (ODS)
+zenodotos export 1abc123def456ghi789jkl012mno345pqr678stu901vwx --format ods
 
 # Export a presentation to HTML instead of PDF
 zenodotos export 1abc123def456ghi789jkl012mno345pqr678stu901vwx --format html

--- a/src/zenodotos/cli/commands.py
+++ b/src/zenodotos/cli/commands.py
@@ -162,7 +162,7 @@ def get_file(file_id, query, fields):
 @click.option(
     "--format",
     type=click.Choice(
-        ["html", "pdf", "xlsx", "csv", "md", "rtf", "txt", "odt", "epub"]
+        ["html", "pdf", "xlsx", "csv", "md", "rtf", "txt", "odt", "ods", "epub"]
     ),
     help="Export format (auto-detected if not specified)",
 )
@@ -181,7 +181,7 @@ def export(file_id, query, output, format, verbose):
     - Google Drawings: PNG
     - Google Forms: ZIP
 
-    Use --format to override the default format. Supported formats: html, pdf, xlsx, csv, md, rtf, txt, odt, epub
+    Use --format to override the default format. Supported formats: html, pdf, xlsx, csv, ods, md, rtf, txt, odt, epub
 
     Either FILE_ID or --query must be provided. Use --query to search for files by name or other criteria.
     """

--- a/src/zenodotos/drive/client.py
+++ b/src/zenodotos/drive/client.py
@@ -214,6 +214,7 @@ class DriveClient:
             "rtf",
             "txt",
             "odt",
+            "ods",
             "epub",
         ]
         if format not in supported_formats:
@@ -268,6 +269,7 @@ class DriveClient:
             "rtf": "application/rtf",
             "txt": "text/plain",
             "odt": "application/vnd.oasis.opendocument.text",
+            "ods": "application/vnd.oasis.opendocument.spreadsheet",
             "epub": "application/epub+zip",
         }
         return mime_type_mapping.get(format, "application/zip")
@@ -290,6 +292,7 @@ class DriveClient:
             "rtf": "rtf",
             "txt": "txt",
             "odt": "odt",
+            "ods": "ods",
             "epub": "epub",
         }
         return extension_mapping.get(format, "zip")


### PR DESCRIPTION
- Add ODS (OpenDocument Spreadsheet) format to supported export formats
- Update CLI command to include 'ods' in format choices
- Add ODS MIME type mapping: application/vnd.oasis.opendocument.spreadsheet
- Add ODS file extension mapping: .ods
- Update documentation in README.md and export-command.md
- Add comprehensive test for ODS format export functionality
- Update CLI help text to include ODS in supported formats list

This enables users to export Google Sheets directly to LibreOffice Sheets format, which is natively supported by the Google Drive API. The ODS format provides better compatibility with open-source office suites and maintains formatting and structure of the original spreadsheet.